### PR TITLE
Remove Mixpanel integration

### DIFF
--- a/resin FAQ hotspot bingo.htm
+++ b/resin FAQ hotspot bingo.htm
@@ -18,7 +18,7 @@
     <link rel="stylesheet" type="text/css" href="file:///Users/chriswilkes/resin/bingo.css">
     <link rel="image_src" href="https://www.bullshitbingo.net/parts/img/bsbingo.png">
 
-    <script src="./resin FAQ hotspot bingo_files/tracker.js"></script><script type="text/javascript" async="" src="./resin FAQ hotspot bingo_files/mixpanel-2-latest.min.js"></script><script async="" src="./resin FAQ hotspot bingo_files/analytics.js"></script><script type="text/javascript">
+    <script type="text/javascript">
     var faqs = [];
 
     function click(){
@@ -959,18 +959,6 @@ function editText() {
 
   ga('create', 'UA-45671959-1', 'auto');
   ga('send', 'pageview');
-</script>
-
-<!-- start Mixpanel -->
-<script type="text/javascript">(function(f,b){if(!b.__SV){var a,e,i,g;window.mixpanel=b;b._i=[];b.init=function(a,e,d){function f(b,h){var a=h.split(".");2==a.length&&(b=b[a[0]],h=a[1]);b[h]=function(){b.push([h].concat(Array.prototype.slice.call(arguments,0)))}}var c=b;"undefined"!==typeof d?c=b[d]=[]:d="mixpanel";c.people=c.people||[];c.toString=function(b){var a="mixpanel";"mixpanel"!==d&&(a+="."+d);b||(a+=" (stub)");return a};c.people.toString=function(){return c.toString(1)+".people (stub)"};i="disable track track_pageview track_links track_forms register register_once alias unregister identify name_tag set_config people.set people.set_once people.increment people.append people.track_charge people.clear_charges people.delete_user".split(" ");
-for(g=0;g<i.length;g++)f(c,i[g]);b._i.push([a,e,d])};b.__SV=1.2;a=f.createElement("script");a.type="text/javascript";a.async=!0;a.src="http://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";e=f.getElementsByTagName("script")[0];e.parentNode.insertBefore(a,e)}})(document,window.mixpanel||[]);
-mixpanel.init("99eec53325d4f45dd0633abd719e3ff1");</script>
-<!-- end Mixpanel -->
-
-<script type="text/javascript">
-  document.addEventListener("DOMContentLoaded", function(event) {
-    mixpanel.track('Docs', { page: location.href });
-  });
 </script>
 
 <!-- GoSquared -->


### PR DESCRIPTION
This project has been started by cloning one of the docs.resin.io pages
using HTTrack, which included all the code necessary to send events to
our production Mixpanel application.

I'm removing this code, as probably we don't need to track events on a
demo project, and even if so, we should not be using our production
Mixpanel token for it.

Change-type: patch